### PR TITLE
bugfix: apply change query keys to post model

### DIFF
--- a/src/spaceone/board/model/board_model.py
+++ b/src/spaceone/board/model/board_model.py
@@ -20,9 +20,6 @@ class Board(MongoModel):
             'board_id',
             'name'
         ],
-        'change_query_keys': {
-            'user_domains': 'domain_id'
-        },
         'ordering': [
             'name'
         ],

--- a/src/spaceone/board/model/post_model.py
+++ b/src/spaceone/board/model/post_model.py
@@ -35,6 +35,9 @@ class Post(MongoModel):
             'board_id',
             'post_id',
         ],
+        'change_query_keys': {
+            'user_domains': 'domain_id'
+        },
         'ordering': [
             '-created_at'
         ],


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@megazone.com>

### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
```python
@transaction(append_meta={
        'authorization.scope': 'DOMAIN',
        'mutation.append_parameter': {'user_domains': {'meta': 'domain_id', 'data': [None]}},
    })
    @check_required(['board_id'])
    @append_query_filter(['post_id', 'category', 'writer', 'user_id', 'domain_id', 'user_domains'])
    def list(self, params):
          ...
```
In the list method of the post, user_domains is used, but it was confirmed that it was incorrectly applied to the board model.
